### PR TITLE
change style of the cursor on nav link

### DIFF
--- a/React_Starter/scss/core/_nav.scss
+++ b/React_Starter/scss/core/_nav.scss
@@ -1,7 +1,7 @@
 .nav-tabs {
   .nav-link {
     color: $gray-600;
-    &.hover {
+    &:hover {
       cursor: pointer;
     }
     &.active {

--- a/React_Starter/scss/core/_nav.scss
+++ b/React_Starter/scss/core/_nav.scss
@@ -1,6 +1,9 @@
 .nav-tabs {
   .nav-link {
     color: $gray-600;
+    &.hover {
+      cursor: pointer;
+    }
     &.active {
       color: $gray-800;
       background: #fff;


### PR DESCRIPTION
The current behavior is to display the `text` cursor when on hover, even though `nav-link` is an anchor.

It does not display the `pointer` cursor because `nav-link` is missing the `href` attribute.